### PR TITLE
Update index.tpl date and teraslice github url

### DIFF
--- a/index.tpl
+++ b/index.tpl
@@ -173,7 +173,7 @@
                   <p class="info">
                     {{ (index $chartEntry 0).Name }}
                     ({{ (index $chartEntry 0).Version }}@{{ (index $chartEntry 0).AppVersion }})
-                    <a href="https://github.com/terascope/teraslice/pkgs/container/{{ $key }}">
+                    <a href="https://github.com/terascope/teraslice">
                       <img src="images/GitHub-Mark-32px.png" alt="github link" style="height: 16px; width: 16px; vertical-align: middle;" />
                     </a>
                   </p>
@@ -208,6 +208,6 @@
 			{{end}}
       </div>
     </section>
-		<time datetime="{{ .Generated.Format "2006-01-02T15:04:05" }}" pubdate id="generated">{{ .Generated.Format "Mon Jan 2 2006 03:04:05PM MST-07:00" }}</time>
+		<time datetime="BUILD_TIME" pubdate id="generated">BUILD_TIME</time>
   </body>
 </html>


### PR DESCRIPTION
This PR updates the index.tmp
- The `time` html element will now hold a placeholder that will be updated in the `update-gh-pages` workflow
- The teraslice chart github link will go to the main page of the repo