### PR TITLE
overwrite time on index.html

### DIFF
--- a/.github/workflows/update-gh-pages.yaml
+++ b/.github/workflows/update-gh-pages.yaml
@@ -67,6 +67,11 @@ jobs:
           helm plugin install https://github.com/halkeye/helm-repo-html
           helm repo-html
 
+      - name: Update index.html timestamp
+        run: | 
+          current_date=$(date -u '+%a %b %d %Y %I:%M:%S%p UTC%z' | sed -E 's/(UTC[+-][0-9]{2})([0-9]{2})/\1:\2/')
+          sed -i "s/BUILD_TIME/$current_date/g" index.html
+
       - name: Upload all files as artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
This PR updates the `update-gh-pages` workflow to overwrite the `BUILD_TIME` placeholder in the index.html with the current time before publishing.