### PR TITLE
use gh api to get teraslice index.yaml

### DIFF
--- a/.github/workflows/update-gh-pages.yaml
+++ b/.github/workflows/update-gh-pages.yaml
@@ -42,7 +42,10 @@ jobs:
 
       - name: Download index.yaml from teraslice repo
         run: |
-          curl -Ss https://terascope.github.io/teraslice/charts/index.yaml > teraslice-index.yaml
+          gh api -H "Accept: application/vnd.github.v3.raw" \
+          /repos/terascope/teraslice/contents/helm/helm-repo-site/index.yaml > teraslice-index.yaml
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Merge teraslice's index.yaml
         run: |


### PR DESCRIPTION
This PR updates the `update-gh-pages` workflow to use `gh api` to pull the teraslice `index.yaml` directly from the master branch instead of the docs page, as the page might not refresh before the workflow is triggered by teraslice. 