### PR TITLE
fix ordering of teraslice chart versions

### DIFF
--- a/.github/workflows/update-gh-pages.yaml
+++ b/.github/workflows/update-gh-pages.yaml
@@ -52,15 +52,19 @@ jobs:
           # merge index.yaml files
           yq eval-all '. | select(fileIndex == 0) *+ select(fileIndex == 1)' index.yaml teraslice-index.yaml > merged-index.yaml
 
-          # remove duplicates and sort by version in descending order          
-          yq -i '
-            .entries.teraslice-chart |= unique_by(.version) |
-            .entries.teraslice-chart |= sort_by(.version) |
-            .entries.teraslice-chart |= reverse
-          ' merged-index.yaml
+          # Remove duplicates and sort by version in descending order.
+          # It is simpler to convert the file to json and use jq, as yq is too limited to easily
+          # sort by major/minor/patch versions. Use pipefail to ensure failures are surfaced.
+          (set -o pipefail; yq -o=json merged-index.yaml |
+          jq '
+            .entries["teraslice-chart"] |= unique_by(.version) |
+            .entries["teraslice-chart"] |= sort_by(.version | split(".") | map(tonumber)) |
+            .entries["teraslice-chart"] |= reverse
+          ' |
+           yq -P) > sorted-index.yaml
 
-          # replace old index.yaml with merged
-          mv merged-index.yaml index.yaml
+          # replace old index.yaml with merged and sorted index
+          mv sorted-index.yaml index.yaml
 
           # remove teraslice-index.yaml so it doesn't get merged
           rm teraslice-index.yaml


### PR DESCRIPTION
This PR updates the `update-gh-pages.yml` workflow to sort teraslice chart versions correctly. Previously the sort failed because the version is a string, so 1.10.0 would be listed before 1.9.0. We now split the version into an array of major/minor/patch, convert the strings to numbers, then sort the chart versions by their version array.  This was difficult to do in yq, so we convert the yaml to json, use jq to sort, then convert back to yaml.