### PR TITLE
[kafka chart] fix possible duplicate env var in statefulset

### DIFF
--- a/charts/kafka/Chart.yaml
+++ b/charts/kafka/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed commit log.
 name: kafka
-version: 1.2.0
+version: 1.3.0
 appVersion: 3.7.1
 keywords:
 - kafka

--- a/charts/kafka/README.md
+++ b/charts/kafka/README.md
@@ -2,7 +2,7 @@
 
 ## Chart Version
 
-1.2.0
+1.3.0
 
 ## App Version
 

--- a/charts/kafka/templates/_helpers.tpl
+++ b/charts/kafka/templates/_helpers.tpl
@@ -71,14 +71,6 @@ Derive statefulset broker configuration settings in following priority order: co
 {{- end -}}
 
 {{/*
-Derive offsets.topic.replication.factor in following priority order: configurationOverrides, replicas
-*/}}
-{{- define "kafka.replication.factor" }}
-{{- $replicationFactorOverride := index .Values "configurationOverrides" "offsets.topic.replication.factor" }}
-{{- default .Values.replicas $replicationFactorOverride }}
-{{- end -}}
-
-{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "kafka.chart" -}}

--- a/charts/kafka/templates/statefulset.yaml
+++ b/charts/kafka/templates/statefulset.yaml
@@ -177,8 +177,10 @@ spec:
               fieldPath: metadata.namespace
         - name: KAFKA_HEAP_OPTS
           value: {{ .Values.kafkaHeapOptions }}
+        {{- if not (hasKey .Values.configurationOverrides "offsets.topic.replication.factor") }}
         - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
-          value: {{ include "kafka.replication.factor" . | quote }}
+          value: {{ .Values.replicas | quote }}
+        {{- end }}  
         {{- $brokerConfigs := fromYaml (include "kafka.brokerConfigs" .) }}
         {{- range $key, $value :=  $brokerConfigs }}
         - name: {{ printf "KAFKA_%s" $key | replace "." "_" | upper | quote }}
@@ -186,7 +188,7 @@ spec:
         {{- end }}  
         {{- if .Values.prometheus.agent.enabled }}
         - name: KAFKA_JMX_OPTS
-          value: "-Dcom.sun.management.jmxremote={{ .Values.jmx.remote.enabled }} -Dcom.sun.management.jmxremote.port={{ .Values.jmx.port }} -Dcom.sun.management.jmxremote.local.port={{ .Values.jmx.port }} -Dcom.sun.management.jmxremote.local.only={{ .Values.jmx.remote.localOnly }} -Dcom.sun.management.jmxremote.authenticate={{ .Values.jmx.remote.authenticate }} -Dcom.sun.management.jmxremote.ssl=={{ .Values.jmx.remote.ssl }} -javaagent:/var/lib/prometheus/jmx_prometheus_javaagent-{{ .Values.prometheus.agent.version }}.jar={{ .Values.prometheus.agent.port }}:/etc/prometheus/jmx-kafka-prometheus.yml"
+          value: "-Dcom.sun.management.jmxremote={{ .Values.jmx.remote.enabled }} -Dcom.sun.management.jmxremote.port={{ .Values.jmx.port }} -Dcom.sun.management.jmxremote.local.port={{ .Values.jmx.port }} -Dcom.sun.management.jmxremote.local.only={{ .Values.jmx.remote.localOnly }} -Dcom.sun.management.jmxremote.authenticate={{ .Values.jmx.remote.authenticate }} -Dcom.sun.management.jmxremote.ssl={{ .Values.jmx.remote.ssl }} -javaagent:/var/lib/prometheus/jmx_prometheus_javaagent-{{ .Values.prometheus.agent.version }}.jar={{ .Values.prometheus.agent.port }}:/etc/prometheus/jmx-kafka-prometheus.yml"
         {{- end }}
         {{- if not .Values.prometheus.agent.enabled }}
         - name: KAFKA_JMX_OPTS
@@ -260,7 +262,7 @@ spec:
           {{- toYaml .Values.extraVolumeMounts | nindent 8 }}
         {{- end }}
       {{- if .Values.extraContainers }}
-        {{ toYaml .Values.extraContainers | indent 8 }}
+      {{- toYaml .Values.extraContainers | nindent 6 }}
       {{- end }}
       volumes:
       {{- if not .Values.persistence.enabled }}
@@ -281,7 +283,7 @@ spec:
         emptyDir: {}
       {{- end }}
       {{- if .Values.extraVolumes }}
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}
       {{- if .Values.securityContext }}
       securityContext:


### PR DESCRIPTION
This PR makes the following changes:
- bump chart to v1.3.0
- remove `offsets.topic.replication.factor` logic from `templates/_helpers` as this could cause duplicate env vars to be added to the statefulset, which caused helm v4 to error.
- update statefulset to only add `offsets.topic.replication.factor` if it is not specified in the `configurationOverrides`
ref: #17